### PR TITLE
Fix SPI initialization for libopencm3 update

### DIFF
--- a/opendps/spi_driver.c
+++ b/opendps/spi_driver.c
@@ -53,7 +53,8 @@ void spi_init(void)
 
     rcc_periph_clock_enable(RCC_SPI2);
     rcc_periph_clock_enable(RCC_DMA1);
-    rcc_periph_reset_pulse(RST_SPI2);
+    rcc_periph_reset_hold(RST_SPI2);
+    rcc_periph_reset_release(RST_SPI2);
     SPI2_I2SCFGR = 0;
     spi_init_master(SPI2, SPI_CR1_BAUDRATE_FPCLK_DIV_2, SPI_CR1_CPOL_CLK_TO_1_WHEN_IDLE, SPI_CR1_CPHA_CLK_TRANSITION_2, SPI_CR1_DFF_8BIT, SPI_CR1_MSBFIRST);
 


### PR DESCRIPTION
## Summary
Fixes black screen issue on DPS5015 after recent libopencm3 update that broke SPI initialization sequence.

## Changes
- Replace `rcc_periph_reset_pulse(RST_SPI2)` with explicit `rcc_periph_reset_hold()` / `rcc_periph_reset_release()` sequence
- Restores display functionality on ILI9163C controller

## Root Cause
Recent libopencm3 update changed how `rcc_periph_reset_pulse()` behaves, causing SPI initialization to fail and resulting in black screen on device boot.

## Testing
- Tested on DPS5015 hardware with Black Magic Probe
- Display now functions correctly after firmware flash
- No other functionality affected

🤖 Generated with [Claude Code](https://claude.ai/code)